### PR TITLE
modify throwing error

### DIFF
--- a/sample/tutorial.js
+++ b/sample/tutorial.js
@@ -170,7 +170,7 @@ var answers = apart
     .SelectMany(function(miller){ return apart
     .Select(function(smith){ return {
         baker: baker, cooper: cooper, fletcher: fletcher, miller: miller, smith: smith}})})})})})
-    .Where("Enumerable.From($).Distinct('$.Value').Count() == 5")
+    .Where(function(x){ return Enumerable.From(x).Distinct("$.Value").Count() == 5;})
     .Where("$.baker != 5")
     .Where("$.cooper != 1")
     .Where("$.fletcher != 1 && $.fletcher != 5")


### PR DESCRIPTION
Hi

An error occurs in running sample/tutorial.js as below.

 Nondeterministic Programs

 node.js:201
         throw e; // process.nextTick error, or 'error' event on first tick
                 ^
 ReferenceError: Enumerable is not defined

As "Enumerable" is not global object anymore by your commit ( mihaifm/linq@4905bebcc7e9ed2e66cd6ed2b6de0fb893dde034 ), string literal cannot eval as function.

I think it is better string literal cannot use in npm linq.
What do you think of?
