### PR TITLE
Adding the `main` and `ignore` fields in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,14 +10,14 @@
     "CHANGELOG",
     "package.json"
   ],
-  "homepage": "https://github.com/danyim/linq",
+  "homepage": "https://github.com/mihaifm/linq",
   "_release": "6b76ff6f5f",
   "_resolution": {
     "type": "branch",
     "branch": "master",
-    "commit": "7138dec96607664c96787635552a89aec90e5d8c"
+    "commit": "6b76ff6f5f77d3a4f7a7812bb9a979536f7e5e78"
   },
-  "_source": "git://github.com/danyim/linq.git",
+  "_source": "git://github.com/mihaifm/linq.git",
   "_target": "*",
   "_originalSource": "linqjs",
   "_direct": true


### PR DESCRIPTION
This is required for `bower install` to install this package without warnings and for Gulp's `wiredep` to run properly when using this component.
