### PR TITLE
Fix projection.selectMany test.

### DIFF
--- a/test/projection.js
+++ b/test/projection.js
@@ -47,13 +47,21 @@ test("select", function () {
 });
 
 test("selectMany", function () {
-    actual = Enumerable.range(1, 5).selectMany("i=>Enumerable.repeat(i,2)").toArray();
+    actual = Enumerable.range(1, 5)
+        .selectMany(function(i) { return Enumerable.repeat(i, 2); })
+        .toArray();
     deepEqual(actual, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5]);
-    actual = Enumerable.range(1, 5).selectMany("i,index=>Enumerable.repeat(i,index+1)").toArray();
+    actual = Enumerable.range(1, 5)
+        .selectMany(function(i, index) { return Enumerable.repeat(i, index + 1); })
+        .toArray();
     deepEqual(actual, [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]);
-    actual = Enumerable.range(1, 5).selectMany("i=>Enumerable.repeat(i,2)", "i=>i*10").toArray();
+    actual = Enumerable.range(1, 5)
+        .selectMany(function(i) { return Enumerable.repeat(i, 2); }, "i=>i*10")
+        .toArray();
     deepEqual(actual, [10, 10, 20, 20, 30, 30, 40, 40, 50, 50]);
-    actual = Enumerable.range(1, 5).selectMany("i,index=>Enumerable.repeat(i,index+1)", "i=>i*10").toArray();
+    actual = Enumerable.range(1, 5)
+        .selectMany(function(i, index) { return Enumerable.repeat(i, index + 1); }, "i=>i*10")
+        .toArray();
     deepEqual(actual, [10, 20, 20, 30, 30, 30, 40, 40, 40, 40, 50, 50, 50, 50, 50]);
 });
 


### PR DESCRIPTION
The test used to fail with the following error:
```
Module: Projection Test: selectMany
Died on test #1     at Object.<anonymous> (X:\linq\test\projection.js:49:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19): Enumerable is not defined
ReferenceError: Enumerable is not defined
    at eval (eval at createLambda (X:\linq\linq.min.js:1:552), <anonymous>:3:8)
    at D.<anonymous> (X:\linq\linq.min.js:17:149)
    at g.moveNext (X:\linq\linq.min.js:3:19)
    at d.forEach (X:\linq\linq.min.js:47:466)
    at d.toArray (X:\linq\linq.min.js:45:208)
    at Object.<anonymous> (X:\linq\test\projection.js:50:77)
    at Object.run (X:\linq\node_modules\qunit\support\qunit\qunit\qunit.js:136:18)
    at X:\linq\node_modules\qunit\support\qunit\qunit\qunit.js:279:10
    at process (X:\linq\node_modules\qunit\support\qunit\qunit\qunit.js:1235:24)
    at Timeout._onTimeout (X:\linq\node_modules\qunit\support\qunit\qunit\qunit.js:378:5)
```