### PR TITLE
[do not merge] Add es2015 iterator support

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -33,7 +33,7 @@ declare namespace Enumerable {
   export function unfold<T>(seed: T, func: (value: T) => T): IEnumerable<T>;
   export function defer<T>(enumerableFactory: () => IEnumerable<T>): IEnumerable<T>;
 
-  export interface IEnumerable<T> {
+  export interface IEnumerable<T> extends Iterable<T> {
     constructor(getEnumerator: () => IEnumerator<T>);
     getEnumerator(): IEnumerator<T>;
 
@@ -160,6 +160,7 @@ declare namespace Enumerable {
     asEnumerable(): IEnumerable<T>;
     cast<TResult>(): IEnumerable<TResult>;
     toArray(): T[];
+    [Symbol.iterator](): Iterator<T>;
     // truly, return type is ILookup<TKey, T> but Visual Studio + TypeScript Compiler can't compile. 
     toLookup<TKey>(keySelector: (element: T) => TKey): ILookup<TKey, any>;
     toLookup<TKey, TElement>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement): ILookup<TKey, TElement>;

--- a/linq.js
+++ b/linq.js
@@ -2152,6 +2152,25 @@
         return array;
     };
 
+    /* Iterator (ES6 for..of) support */
+    if (typeof Symbol !== 'undefined' && typeof Symbol.iterator !== 'undefined') {
+        Enumerable.prototype[Symbol.iterator] = function () {
+            var enumerator = this.getEnumerator();
+            return {
+                next: function () {
+                    if (enumerator.moveNext()) {
+                        return {
+                            done: false,
+                            value: enumerator.current()
+                        };
+                    } else {
+                        return { done: true };
+                    }
+                }
+            };
+        };
+    }
+
     // Overload:function(keySelector)
     // Overload:function(keySelector, elementSelector)
     // Overload:function(keySelector, elementSelector, compareSelector)

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -1,0 +1,21 @@
+var module = QUnit.module;
+var Enumerable = require('../linq');
+require("../extensions/linq.qunit.js")({'Enumerable': Enumerable});
+
+if (typeof Symbol !== 'undefined' && typeof Symbol.iterator !== 'undefined') {
+
+    module("Iterator");
+
+    var actual, expected;
+
+    test("for..of", function ()
+    {
+        actual = [1,2,3,4];
+        expected = Array.from(Enumerable.from(actual));
+        deepEqual(actual, expected);
+        var actual2 = actual.map(function(x) { return x * 2 }); // [2,4,6,8];
+        expected = Enumerable.from(actual).select(function(x) { return x * 2 });
+        deepEqual(actual2, Array.from(expected));
+    });
+
+}

--- a/test/testrunner.js
+++ b/test/testrunner.js
@@ -5,7 +5,7 @@ var callback = function(err, report) {
 }
 tr.run({
     code: "./linq.min.js",
-    tests: "./test/linq.min.qunit-test.js"
+    tests: "./test/linq.qunit-test.js"
 }, callback);
 
 tr.run({
@@ -81,4 +81,9 @@ tr.run({
 tr.run({
     code: "./linq.min.js",
     tests: "./test/whereSelectEnumerable.js"
+}, callback);
+
+tr.run({
+    code: "./linq.min.js",
+    tests: "./test/iterator.js"
 }, callback);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es2015.iterable"
+        ]
+    }
+}


### PR DESCRIPTION
* Adds es2015 iterator support
* Adds a simple test to see if Array.from works (can't use for..of as that would prevent pre-node-v4 from running tests)
* Typescript: Makes IEnumerable<T> extend Iterator<T>

if iterators aren't supported, nothing is applied/tested. typescript should also ignore the Iterator<T> when not targeting es6.