### PR TITLE
Cast to number, avoid string concat.

### DIFF
--- a/linq.js
+++ b/linq.js
@@ -1802,7 +1802,7 @@
     // Overload:function(selector)
     Enumerable.prototype.sum = function (selector) {
         if (selector == null) selector = Functions.Identity;
-        return this.select(selector).aggregate(0, function (a, b) { return a + b; });
+        return this.select(selector).aggregate(0, function (a, b) { return Number(a) + Number(b); });
     };
 
     /* Paging Methods */


### PR DESCRIPTION
before:
 0+"100"="0100"
after:
0+"100"=100