### PR TITLE
Use new JS lambda syntax in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Enumerable.Range(1, 10)
 ```
 
 ```js
-// C# LINQ  - lambda
+// C# LINQ - lambda
 Enumerable.Range(1, 10).Where(i => i % 3 == 0).Select(i => i * 10);
 
-// linq.js - lambda expression
-Enumerable.Range(1, 10).Where("i => i % 3 == 0").Select("i => i * 10");
+// linq.js - arrow function
+Enumerable.Range(1, 10).Where(i => i % 3 == 0).Select(i => i * 10);
 ```
 
 ```js
@@ -33,7 +33,7 @@ Enumerable.Range(1, 10).Where("i => i % 3 == 0").Select("i => i * 10");
 array.Select((val, i) => new { Value = val, Index = i });
 
 // linq.js - object literal
-Enumerable.From(array).Select("val,i=>{Value:val, Index:i}");
+Enumerable.From(array).Select((val, i) => ({ Value: val, Index: i}));
 ```
 
 See [sample/tutorial.js](https://github.com/mihaifm/linq/blob/master/sample/tutorial.js) for more examples.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Enumerable.Range(1, 10)
 
 // linq.js - anonymous function
 Enumerable.Range(1, 10)
-    .Where(function(i) { return i % 3 == 0; })
-    .Select(function(i) { return i * 10; });
+    .where(function(i) { return i % 3 == 0; })
+    .select(function(i) { return i * 10; });
 ```
 
 ```js
@@ -25,7 +25,7 @@ Enumerable.Range(1, 10)
 Enumerable.Range(1, 10).Where(i => i % 3 == 0).Select(i => i * 10);
 
 // linq.js - arrow function
-Enumerable.Range(1, 10).Where(i => i % 3 == 0).Select(i => i * 10);
+Enumerable.range(1, 10).where(i => i % 3 == 0).select(i => i * 10);
 ```
 
 ```js
@@ -33,7 +33,7 @@ Enumerable.Range(1, 10).Where(i => i % 3 == 0).Select(i => i * 10);
 array.Select((val, i) => new { Value = val, Index = i });
 
 // linq.js - object literal
-Enumerable.From(array).Select((val, i) => ({ Value: val, Index: i}));
+Enumerable.from(array).select((val, i) => ({ value: val, index: i}));
 ```
 
 See [sample/tutorial.js](https://github.com/mihaifm/linq/blob/master/sample/tutorial.js) for more examples.

--- a/sample/tutorial.js
+++ b/sample/tutorial.js
@@ -8,14 +8,14 @@ console.log('\nfirst step of Lambda Expression\n');
 // Anonymous function
 Enumerable.range(1, 3).select(function(value, index) { return index + ':' + value }).log().toJoinedString();
 // String like Lambda Expression (arguments => expression)
-Enumerable.range(1, 3).select("value,index=>index+':'+value").log().toJoinedString();
+Enumerable.range(1, 3).select((value, index) => index + ':' + value).log().toJoinedString();
 
 // If the number of arguments is one , can use default iterator variable '$'
-Enumerable.range(1, 3).select("i=>i*2").log().toJoinedString();
+Enumerable.range(1, 3).select(i => i * 2).log().toJoinedString();
 Enumerable.range(1, 3).select("$*2").log().toJoinedString(); // same
 
 // "" is shortcut of "x => x" (identity function)
-Enumerable.range(4, 7).join(Enumerable.range(8, 5), "", "", "outer,inner=>outer*inner").log().toJoinedString();
+Enumerable.range(4, 7).join(Enumerable.range(8, 5), "", "", (outer, inner) => outer * inner).log().toJoinedString();
 
 
 
@@ -117,7 +117,7 @@ Enumerable.matches(input, "ab(.)d", "i").forEach(function(match)
 console.log('\nLazyEvaluation and InfinityList\n');
 
 // first radius of circle's area over 10000
-var result = Enumerable.toInfinity(1).where("r=>r*r*Math.PI>10000").first();
+var result = Enumerable.toInfinity(1).where(r => r * r * Math.PI > 10000).first();
 console.log(result);
 
 


### PR DESCRIPTION
For some time now, JS has a new lambda syntax, i. e. `(x, y) => x + y`. It can be used in the docs now  instead of 'lambda expression' strings as it looks nicer and should work faster, too. (It's supported by all major browsers now and also in Node.js, so it is probably safe to ditch the 'lambda expression' parser as well?)