### PR TITLE
Added missing TypeScript function definition in IGrouping interface.

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -229,6 +229,7 @@ declare namespace Enumerable {
 
   export interface IGrouping<TKey, TElement> extends IEnumerable<TElement> {
     key(): TKey;
+    getSource(): TElement[];
   }
 }
 


### PR DESCRIPTION
Hi, i think i found missing TS definition then i added it.
I am adding images where is showed reason why i think it is really missing.
![linqjs](https://user-images.githubusercontent.com/24366574/37087819-b049a69e-21fb-11e8-8545-7cd04b99eeb2.png)
![linqjs2](https://user-images.githubusercontent.com/24366574/37087820-b06781e6-21fb-11e8-8040-0092aecc076f.png)

