### PR TITLE
Update ts declaration for buffer fn

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -126,7 +126,7 @@ declare namespace Enumerable {
     partitionBy<TKey, TElement>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement): IEnumerable<IGrouping<TKey, TElement>>;
     partitionBy<TKey, TElement, TResult>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, resultSelector: (key: TKey, element: IEnumerable<TElement>) => TResult): IEnumerable<TResult>;
     partitionBy<TKey, TElement, TResult, TCompare>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, resultSelector: (key: TKey, element: IEnumerable<TElement>) => TResult, compareSelector: (element: TKey) => TCompare): IEnumerable<TResult>;
-    buffer(count: number): IEnumerable<T>;
+    buffer(count: number): IEnumerable<T[]>;
     aggregate(func: (prev: T, current: T) => T): T;
     aggregate<TAccumulate>(seed: TAccumulate, func: (prev: TAccumulate, current: T) => TAccumulate): TAccumulate;
     aggregate<TAccumulate, TResult>(seed: TAccumulate, func: (prev: TAccumulate, current: T) => TAccumulate, resultSelector: (last: TAccumulate) => TResult): TResult;


### PR DESCRIPTION
According to [test file](https://github.com/mihaifm/linq/blob/ffaf2f99ec7aa5de1155dc46f76d847ab67e72cb/test/grouping.js#L111) and implementation, buffer function must group items into arrays. TS definitions doesn't reflect the current situation, so I update linq.d.ts file to insert correct typings