### PR TITLE
Fix TypeScript definitions for orderBy, orderByDescending, thenBy and…

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -113,9 +113,9 @@ declare namespace Enumerable {
     sequenceEqual(second: T[]): boolean;
     sequenceEqual<TCompare>(second: T[], compareSelector: (element: T) => TCompare): boolean;
     orderBy<TKey>(keySelector: (element: T) => TKey): IOrderedEnumerable<T>;
-    orderBy<TKey>(keySelector: (element: T) => TKey, comparer: (first: T, second: T) => number): IOrderedEnumerable<T>;
+    orderBy<TKey>(keySelector: (element: T) => TKey, comparer: (first: TKey, second: TKey) => number): IOrderedEnumerable<T>;
     orderByDescending<TKey>(keySelector: (element: T) => TKey): IOrderedEnumerable<T>;
-    orderByDescending<TKey>(keySelector: (element: T) => TKey, comparer: (first: T, second: T) => number): IOrderedEnumerable<T>;
+    orderByDescending<TKey>(keySelector: (element: T) => TKey, comparer: (first: TKey, second: TKey) => number): IOrderedEnumerable<T>;
     reverse(): IEnumerable<T>;
     shuffle(): IEnumerable<T>;
     weightedSample(weightSelector: (element: T) => number): IEnumerable<T>;
@@ -206,11 +206,11 @@ declare namespace Enumerable {
   }
 
   export interface IOrderedEnumerable<T> extends IEnumerable<T> {
-    createOrderedEnumerable<TKey>(keySelector: (element: T) => TKey, comparer?: (first: T, second: T) => number, descending?: boolean): IOrderedEnumerable<T>;
+    createOrderedEnumerable<TKey>(keySelector: (element: T) => TKey, comparer?: (first: TKey, second: TKey) => number, descending?: boolean): IOrderedEnumerable<T>;
     thenBy<TKey>(keySelector: (element: T) => TKey): IOrderedEnumerable<T>;
-    thenBy<TKey>(keySelector: (element: T) => TKey, comparer: (first: T, second: T) => number): IOrderedEnumerable<T>;
+    thenBy<TKey>(keySelector: (element: T) => TKey, comparer: (first: TKey, second: TKey) => number): IOrderedEnumerable<T>;
     thenByDescending<TKey>(keySelector: (element: T) => TKey): IOrderedEnumerable<T>;
-    thenByDescending<TKey>(keySelector: (element: T) => TKey, comparer: (first: T, second: T) => number): IOrderedEnumerable<T>;
+    thenByDescending<TKey>(keySelector: (element: T) => TKey, comparer: (first: TKey, second: TKey) => number): IOrderedEnumerable<T>;
   }
 
   export interface IDisposableEnumerable<T> extends IEnumerable<T> {


### PR DESCRIPTION
… thenByDescending.

Second parameter type of orderBy method in TypeScript definition seems to be wrong.

Therefore, this correct code will cause a compilation error. 
> Enumerable.from(['A', 'B', 'C']).orderBy(x => x.charCodeAt(0), (a, b) => a - b).toArray()

On the other hand, this incorrect code compiles without errors, but gives a runtime error.
> Enumerable.from(['A', 'B', 'C']).orderBy(x => x.charCodeAt(0), (a, b) => a.charCodeAt(0) - b.charCodeAt(0)).toArray()