### PR TITLE
Fix a TypeScript definition for toDictionary method

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -168,7 +168,7 @@ declare namespace Enumerable {
     toLookup<TKey, TElement, TCompare>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TElement, compareSelector: (key: TKey) => TCompare): ILookup<TKey, TElement>;
     toObject(keySelector: (element: T) => any, elementSelector?: (element: T) => any): Object;
     // :IDictionary<TKey, T>
-    toDictionary<TKey>(keySelector: (element: T) => TKey): IDictionary<TKey, any>;
+    toDictionary<TKey>(keySelector: (element: T) => TKey): IDictionary<TKey, T>;
     toDictionary<TKey, TValue>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TValue): IDictionary<TKey, TValue>;
     toDictionary<TKey, TValue, TCompare>(keySelector: (element: T) => TKey, elementSelector: (element: T) => TValue, compareSelector: (key: TKey) => TCompare): IDictionary<TKey, TValue>;
     toJSONString(replacer: (key: string, value: any) => any): string;


### PR DESCRIPTION
If type is 'any', code completion does not work, and typo does not cause compilation error, so it is desirable to avoid the 'any' type as much as possible.

'toDictionary(x => x.key)' is same as 'toDictionary(x => x.key, x => x)'.
Therefore, return type of 'IEnumerable<T>.toDictionary<TKey>(keySelector: (element: T) => TKey)' should be 'IDictionary<TKey, T>'.