### PR TITLE
Add a TypeScript definition for Enumerable.from method

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -18,6 +18,7 @@ declare namespace Enumerable {
   export function from(obj: string): IEnumerable<string>;
   export function from<T>(obj: T[]): IEnumerable<T>;
   export function from<T>(obj: { length: number;[x: number]: T; }): IEnumerable<T>;
+  export function from<T>(obj: { [key: string]: T }): IEnumerable<{ key: string; value: T }>;
   export function from(obj: any): IEnumerable<{ key: string; value: any }>;
   export function make<T>(element: T): IEnumerable<T>;
   export function matches<T>(input: string, pattern: RegExp): IEnumerable<T>;


### PR DESCRIPTION
If type is 'any', code completion does not work, and typo does not cause compilation error, so it is desirable to avoid the 'any' type as much as possible.

Add 'Enumerable.from<T>(obj: { [key: string]: T }): IEnumerable<{ key: string; value: T }>' as definition, the method will return the good type even when the parameter is a hash-like object.