### PR TITLE
Fix a TypeScript definition for concat method

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -72,9 +72,9 @@ declare namespace Enumerable {
     all(predicate: (element: T) => boolean): boolean;
     any(predicate?: (element: T) => boolean): boolean;
     isEmpty(): boolean;
+    concat(...sequences: T[][]): IEnumerable<T>;
     concat(...sequences: IEnumerable<T>[]): IEnumerable<T>;
     concat(...sequences: { length: number;[x: number]: T; }[]): IEnumerable<T>;
-    concat(...sequences: T[]): IEnumerable<T>;
     insert(index: number, second: IEnumerable<T>): IEnumerable<T>;
     insert(index: number, second: { length: number;[x: number]: T; }): IEnumerable<T>;
     alternate(alternateValue: T): IEnumerable<T>;


### PR DESCRIPTION
Variadic arguments are represented as an array of arguments, so if the argument types are arrays, they must be defined as an array of arrays.

This wrong definition allows to pass objects that are not arrays as arguments. It won't cause a run-time error, but the return value won't match the defined type.

In addition, 'T[]' type also matches '{length: number; [x: number]: T;}', so the definition order should be changed.