### PR TITLE
Add Symbol.Iterator support to type definition

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -37,6 +37,7 @@ declare namespace Enumerable {
   export interface IEnumerable<T> {
     constructor(getEnumerator: () => IEnumerator<T>): IEnumerable<T>;
     getEnumerator(): IEnumerator<T>;
+    [Symbol.iterator](): Iterator<T>;
 
     // Extension Methods
     traverseBreadthFirst(childrenSelector: (element: T) => IEnumerable<T>): IEnumerable<T>;


### PR DESCRIPTION
The library supports `for of` an `IEnumerable`, but the typescript definitions for it was missing resulting in typescript thinking you could not.