### PR TITLE
Add Enumerable.from support for Iterator<T>

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -17,6 +17,7 @@ declare namespace Enumerable {
   export function from(obj: boolean): IEnumerable<boolean>;
   export function from(obj: string): IEnumerable<string>;
   export function from<T>(obj: T[]): IEnumerable<T>;
+  export function from<T>(obj: Iterator<T>): IEnumerable<T>;
   export function from<T>(obj: { length: number;[x: number]: T; }): IEnumerable<T>;
   export function from<T>(obj: { [key: string]: T }): IEnumerable<{ key: string; value: T }>;
   export function from(obj: any): IEnumerable<{ key: string; value: any }>;


### PR DESCRIPTION
The library already supports it, but the type-definition did not include it.