### PR TITLE
improve type definition of from(obj: object)

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -21,8 +21,7 @@ declare namespace Enumerable {
   export function from<T>(obj: T[]): IEnumerable<T>;
   export function from<T>(obj: Iterator<T>): IEnumerable<T>;
   export function from<T>(obj: { length: number;[x: number]: T; }): IEnumerable<T>;
-  export function from<T>(obj: { [key: string]: T }): IEnumerable<{ key: string; value: T }>;
-  export function from<T>(obj: Record<PropertyKey, T>): IEnumerable<{ key: string; value: T }>;
+  export function from<K extends PropertyKey, T>(obj: Record<K, T>): IEnumerable<{ key: K; value: T }>;
   export function make<T>(element: T): IEnumerable<T>;
   export function matches<T>(input: string, pattern: RegExp): IEnumerable<T>;
   export function matches<T>(input: string, pattern: string, flags?: string): IEnumerable<T>;


### PR DESCRIPTION
Prior to this change, using `Enumerable.from(...)` on a simple map object with typed keys would lose the key type. This may be intentional due to edge cases with which I am unfamiliar. I am submitting this PR in hopes that is not the case.

```ts
type KeyType = "foo" | "bar" | "baz";

const input: Record<KeyType, number> = {
    foo: 1,
    bar: 2,
    baz: 3
};

const output = Enumerable.from(input)
    .toObject(
        e => e.key,
        e => e.value * 10
    );
    
// result:  output is a `Record<string, number>`

// desired: output is a `Record<KeyType, number>`
```