### PR TITLE
feat: allow iterator

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -20,6 +20,7 @@ declare namespace Enumerable {
   export function from(obj: string): IEnumerable<string>;
   export function from<T>(obj: T[]): IEnumerable<T>;
   export function from<T>(obj: Iterator<T>): IEnumerable<T>;
+  export function from<T>(obj: Iterable<T>): IEnumerable<T>;
   export function from<T>(obj: { length: number;[x: number]: T; }): IEnumerable<T>;
   export function from<K extends PropertyKey, T>(obj: Record<K, T>): IEnumerable<{ key: K; value: T }>;
   export function make<T>(element: T): IEnumerable<T>;

--- a/linq.js
+++ b/linq.js
@@ -4,9 +4,14 @@
  *------------------------------------------------------------------------*/
 
 var Functions = {
-    Identity: function (x) { return x; },
-    True: function () { return true; },
-    Blank: function () { }
+    Identity: function (x) {
+        return x;
+    },
+    True: function () {
+        return true;
+    },
+    Blank: function () {
+    }
 };
 
 var Types = {
@@ -15,10 +20,11 @@ var Types = {
     String: typeof "",
     Object: typeof {},
     Undefined: typeof undefined,
-    Function: typeof function () { }
+    Function: typeof function () {
+    }
 };
 
-var funcCache = { "": Functions.Identity };
+var funcCache = {"": Functions.Identity};
 
 var Utils = {
     createLambda: function (expression) {
@@ -55,8 +61,7 @@ var Utils = {
                 f = new Function(args, "return " + expression);
                 funcCache[expression] = f;
                 return f;
-            }
-            else {
+            } else {
                 const expr = expression.match(/^[(\s]*([^()]*?)[)\s]*=>(.*)/);
                 f = new Function(expr[1], (expr[2].match(/\breturn\b/) ? expr[2] : "return " + expr[2]));
                 funcCache[expression] = f;
@@ -88,7 +93,7 @@ var Utils = {
     }
 };
 
-var State = { Before: 0, Running: 1, After: 2 };
+var State = {Before: 0, Running: 1, After: 2};
 
 var IEnumerator = function (initialize, tryGetNext, dispose) {
     var yielder = new Yielder();
@@ -107,8 +112,7 @@ var IEnumerator = function (initialize, tryGetNext, dispose) {
                 case State.Running:
                     if (tryGetNext.apply(yielder)) {
                         return true;
-                    }
-                    else {
+                    } else {
                         this.dispose();
                         return false;
                     }
@@ -117,8 +121,7 @@ var IEnumerator = function (initialize, tryGetNext, dispose) {
                 case State.After:
                     return false;
             }
-        }
-        catch (e) {
+        } catch (e) {
             this.dispose();
             throw e;
         }
@@ -129,8 +132,7 @@ var IEnumerator = function (initialize, tryGetNext, dispose) {
 
         try {
             dispose();
-        }
-        finally {
+        } finally {
             state = State.After;
         }
     };
@@ -139,7 +141,9 @@ var IEnumerator = function (initialize, tryGetNext, dispose) {
 // tryGetNext yielder
 var Yielder = function () {
     var current = null;
-    this.current = function () { return current; };
+    this.current = function () {
+        return current;
+    };
     this.yieldReturn = function (value) {
         current = value;
         return true;
@@ -180,8 +184,7 @@ Enumerable.Utils.extendTo = function (type) {
         Utils.defineProperty(typeProto, "getSource", function () {
             return this;
         });
-    }
-    else {
+    } else {
         enumerableProto = Enumerable.prototype;
         Utils.defineProperty(typeProto, "getEnumerator", function () {
             return Enumerable.from(this).getEnumerator();
@@ -213,8 +216,7 @@ Enumerable.Utils.recallFrom = function (type) {
     if (type === Array) {
         enumerableProto = ArrayEnumerable.prototype;
         delete typeProto.getSource;
-    }
-    else {
+    } else {
         enumerableProto = Enumerable.prototype;
         delete typeProto.getEnumerator;
     }
@@ -224,8 +226,7 @@ Enumerable.Utils.recallFrom = function (type) {
 
         if (typeProto[methodName + 'ByLinq']) {
             delete typeProto[methodName + 'ByLinq'];
-        }
-        else if (typeProto[methodName] == func && func instanceof Function) {
+        } else if (typeProto[methodName] == func && func instanceof Function) {
             delete typeProto[methodName];
         }
     }
@@ -274,7 +275,9 @@ Enumerable.empty = function () {
     return new Enumerable(function () {
         return new IEnumerator(
             Functions.Blank,
-            function () { return false; },
+            function () {
+                return false;
+            },
             Functions.Blank);
     });
 };
@@ -324,10 +327,12 @@ Enumerable.from = function (obj) {
 
         // iterable object
         if (typeof Symbol !== 'undefined' && typeof obj[Symbol.iterator] !== 'undefined') {
-            let iterator = obj[Symbol.iterator]();
+            let iterator;
             return new Enumerable(function () {
                 return new IEnumerator(
-                    Functions.Blank,
+                    function () {
+                        iterator = obj[Symbol.iterator]()
+                    },
                     function () {
                         var next = iterator.next();
                         return (next.done ? false : (this.yieldReturn(next.value)));
@@ -360,7 +365,7 @@ Enumerable.from = function (obj) {
                 for (const key in obj) {
                     const value = obj[key];
                     if (!(value instanceof Function) && Object.prototype.hasOwnProperty.call(obj, key)) {
-                        array.push({ key: key, value: value });
+                        array.push({key: key, value: value});
                     }
                 }
             },
@@ -392,7 +397,9 @@ Enumerable.matches = function (input, pattern, flags) {
     return new Enumerable(function () {
         var regex;
         return new IEnumerator(
-            function () { regex = new RegExp(pattern, flags); },
+            function () {
+                regex = new RegExp(pattern, flags);
+            },
             function () {
                 var match = regex.exec(input);
                 return (match) ? this.yieldReturn(match) : false;
@@ -411,7 +418,9 @@ Enumerable.range = function (start, count, step) {
         var index = 0;
 
         return new IEnumerator(
-            function () { value = start - step; },
+            function () {
+                value = start - step;
+            },
             function () {
                 return (index++ < count)
                     ? this.yieldReturn(value += step)
@@ -431,7 +440,9 @@ Enumerable.rangeDown = function (start, count, step) {
         var index = 0;
 
         return new IEnumerator(
-            function () { value = start + step; },
+            function () {
+                value = start + step;
+            },
             function () {
                 return (index++ < count)
                     ? this.yieldReturn(value -= step)
@@ -451,7 +462,9 @@ Enumerable.rangeTo = function (start, to, step) {
             var value;
 
             return new IEnumerator(
-                function () { value = start - step; },
+                function () {
+                    value = start - step;
+                },
                 function () {
                     var next = value += step;
                     return (next <= to)
@@ -460,13 +473,14 @@ Enumerable.rangeTo = function (start, to, step) {
                 },
                 Functions.Blank);
         });
-    }
-    else {
+    } else {
         return new Enumerable(function () {
             var value;
 
             return new IEnumerator(
-                function () { value = start + step; },
+                function () {
+                    value = start + step;
+                },
                 function () {
                     var next = value -= step;
                     return (next >= to)
@@ -487,7 +501,9 @@ Enumerable.repeat = function (element, count) {
     return new Enumerable(function () {
         return new IEnumerator(
             Functions.Blank,
-            function () { return this.yieldReturn(element); },
+            function () {
+                return this.yieldReturn(element);
+            },
             Functions.Blank);
     });
 };
@@ -499,8 +515,12 @@ Enumerable.repeatWithFinalize = function (initializer, finalizer) {
     return new Enumerable(function () {
         var element;
         return new IEnumerator(
-            function () { element = initializer(); },
-            function () { return this.yieldReturn(element); },
+            function () {
+                element = initializer();
+            },
+            function () {
+                return this.yieldReturn(element);
+            },
             function () {
                 if (element != null) {
                     finalizer(element);
@@ -521,7 +541,9 @@ Enumerable.generate = function (func, count) {
     return new Enumerable(function () {
         return new IEnumerator(
             Functions.Blank,
-            function () { return this.yieldReturn(func()); },
+            function () {
+                return this.yieldReturn(func());
+            },
             Functions.Blank);
     });
 };
@@ -536,8 +558,12 @@ Enumerable.toInfinity = function (start, step) {
     return new Enumerable(function () {
         var value;
         return new IEnumerator(
-            function () { value = start - step; },
-            function () { return this.yieldReturn(value += step); },
+            function () {
+                value = start - step;
+            },
+            function () {
+                return this.yieldReturn(value += step);
+            },
             Functions.Blank);
     });
 };
@@ -552,8 +578,12 @@ Enumerable.toNegativeInfinity = function (start, step) {
     return new Enumerable(function () {
         var value;
         return new IEnumerator(
-            function () { value = start + step; },
-            function () { return this.yieldReturn(value -= step); },
+            function () {
+                value = start + step;
+            },
+            function () {
+                return this.yieldReturn(value -= step);
+            },
             Functions.Blank);
     });
 };
@@ -584,7 +614,9 @@ Enumerable.defer = function (enumerableFactory) {
         var enumerator;
 
         return new IEnumerator(
-            function () { enumerator = Enumerable.from(enumerableFactory()).getEnumerator(); },
+            function () {
+                enumerator = Enumerable.from(enumerableFactory()).getEnumerator();
+            },
             function () {
                 return (enumerator.moveNext())
                     ? this.yieldReturn(enumerator.current())
@@ -616,7 +648,9 @@ Enumerable.prototype.traverseBreadthFirst = function (func, resultSelector) {
         var buffer = [];
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (true) {
                     if (enumerator.moveNext()) {
@@ -624,11 +658,12 @@ Enumerable.prototype.traverseBreadthFirst = function (func, resultSelector) {
                         return this.yieldReturn(resultSelector(enumerator.current(), nestLevel));
                     }
 
-                    const next = Enumerable.from(buffer).selectMany(function (x) { return func(x); });
+                    const next = Enumerable.from(buffer).selectMany(function (x) {
+                        return func(x);
+                    });
                     if (!next.any()) {
                         return false;
-                    }
-                    else {
+                    } else {
                         nestLevel++;
                         buffer = [];
                         Utils.dispose(enumerator);
@@ -636,7 +671,9 @@ Enumerable.prototype.traverseBreadthFirst = function (func, resultSelector) {
                     }
                 }
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -653,7 +690,9 @@ Enumerable.prototype.traverseDepthFirst = function (func, resultSelector) {
         var enumerator;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (true) {
                     if (enumerator.moveNext()) {
@@ -671,9 +710,10 @@ Enumerable.prototype.traverseDepthFirst = function (func, resultSelector) {
             function () {
                 try {
                     Utils.dispose(enumerator);
-                }
-                finally {
-                    Enumerable.from(enumeratorStack).forEach(function (s) { s.dispose(); });
+                } finally {
+                    Enumerable.from(enumeratorStack).forEach(function (s) {
+                        s.dispose();
+                    });
                 }
             });
     });
@@ -687,14 +727,15 @@ Enumerable.prototype.flatten = function () {
         var middleEnumerator = null;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (true) {
                     if (middleEnumerator != null) {
                         if (middleEnumerator.moveNext()) {
                             return this.yieldReturn(middleEnumerator.current());
-                        }
-                        else {
+                        } else {
                             middleEnumerator = null;
                         }
                     }
@@ -707,8 +748,7 @@ Enumerable.prototype.flatten = function () {
                                 .flatten()
                                 .getEnumerator();
                             continue;
-                        }
-                        else {
+                        } else {
                             return this.yieldReturn(enumerator.current());
                         }
                     }
@@ -719,8 +759,7 @@ Enumerable.prototype.flatten = function () {
             function () {
                 try {
                     Utils.dispose(enumerator);
-                }
-                finally {
+                } finally {
                     Utils.dispose(middleEnumerator);
                 }
             });
@@ -745,7 +784,9 @@ Enumerable.prototype.pairwise = function (selector) {
                     ? this.yieldReturn(selector(prev, enumerator.current()))
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -768,7 +809,9 @@ Enumerable.prototype.scan = function (seed, func) {
         var isFirst = true;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 if (isFirst) {
                     isFirst = false;
@@ -776,8 +819,7 @@ Enumerable.prototype.scan = function (seed, func) {
                         if (enumerator.moveNext()) {
                             return this.yieldReturn(value = enumerator.current());
                         }
-                    }
-                    else {
+                    } else {
                         return this.yieldReturn(value = seed);
                     }
                 }
@@ -786,7 +828,9 @@ Enumerable.prototype.scan = function (seed, func) {
                     ? this.yieldReturn(value = func(value, enumerator.current()))
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -797,8 +841,7 @@ Enumerable.prototype.select = function (selector) {
 
     if (selector.length <= 1) {
         return new WhereSelectEnumerable(this, null, selector);
-    }
-    else {
+    } else {
         var source = this;
 
         return new Enumerable(function () {
@@ -806,13 +849,17 @@ Enumerable.prototype.select = function (selector) {
             var index = 0;
 
             return new IEnumerator(
-                function () { enumerator = source.getEnumerator(); },
+                function () {
+                    enumerator = source.getEnumerator();
+                },
                 function () {
                     return (enumerator.moveNext())
                         ? this.yieldReturn(selector(enumerator.current(), index++))
                         : false;
                 },
-                function () { Utils.dispose(enumerator); });
+                function () {
+                    Utils.dispose(enumerator);
+                });
         });
     }
 };
@@ -824,7 +871,9 @@ Enumerable.prototype.select = function (selector) {
 Enumerable.prototype.selectMany = function (collectionSelector, resultSelector) {
     var source = this;
     collectionSelector = Utils.createLambda(collectionSelector);
-    if (resultSelector == null) resultSelector = function (a, b) { return b; };
+    if (resultSelector == null) resultSelector = function (a, b) {
+        return b;
+    };
     resultSelector = Utils.createLambda(resultSelector);
 
     return new Enumerable(function () {
@@ -833,7 +882,9 @@ Enumerable.prototype.selectMany = function (collectionSelector, resultSelector) 
         var index = 0;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 if (middleEnumerator === undefined) {
                     if (!enumerator.moveNext()) return false;
@@ -854,8 +905,7 @@ Enumerable.prototype.selectMany = function (collectionSelector, resultSelector) 
             function () {
                 try {
                     Utils.dispose(enumerator);
-                }
-                finally {
+                } finally {
                     Utils.dispose(middleEnumerator);
                 }
             });
@@ -869,8 +919,7 @@ Enumerable.prototype.where = function (predicate) {
 
     if (predicate.length <= 1) {
         return new WhereEnumerable(this, predicate);
-    }
-    else {
+    } else {
         var source = this;
 
         return new Enumerable(function () {
@@ -878,7 +927,9 @@ Enumerable.prototype.where = function (predicate) {
             var index = 0;
 
             return new IEnumerator(
-                function () { enumerator = source.getEnumerator(); },
+                function () {
+                    enumerator = source.getEnumerator();
+                },
                 function () {
                     while (enumerator.moveNext()) {
                         if (predicate(enumerator.current(), index++)) {
@@ -887,7 +938,9 @@ Enumerable.prototype.where = function (predicate) {
                     }
                     return false;
                 },
-                function () { Utils.dispose(enumerator); });
+                function () {
+                    Utils.dispose(enumerator);
+                });
         });
     }
 };
@@ -904,7 +957,9 @@ Enumerable.prototype.choose = function (selector) {
         var index = 0;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (enumerator.moveNext()) {
                     const result = selector(enumerator.current(), index++);
@@ -914,7 +969,9 @@ Enumerable.prototype.choose = function (selector) {
                 }
                 return this.yieldBreak();
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -938,8 +995,12 @@ Enumerable.prototype.ofType = function (type) {
             break;
     }
     return (typeName === null)
-        ? this.where(function (x) { return x instanceof type; })
-        : this.where(function (x) { return typeof x === typeName; });
+        ? this.where(function (x) {
+            return x instanceof type;
+        })
+        : this.where(function (x) {
+            return typeof x === typeName;
+        });
 };
 
 // mutiple arguments, last one is selector, others are enumerable
@@ -976,8 +1037,7 @@ Enumerable.prototype.zip = function () {
                     }
                 });
         });
-    }
-    else {
+    } else {
         return new Enumerable(function () {
             var enumerators;
             var index = 0;
@@ -986,19 +1046,24 @@ Enumerable.prototype.zip = function () {
                 function () {
                     var array = Enumerable.make(source)
                         .concat(Enumerable.from(args).takeExceptLast().select(Enumerable.from))
-                        .select(function (x) { return x.getEnumerator() })
+                        .select(function (x) {
+                            return x.getEnumerator()
+                        })
                         .toArray();
                     enumerators = Enumerable.from(array);
                 },
                 function () {
-                    if (enumerators.all(function (x) { return x.moveNext() })) {
+                    if (enumerators.all(function (x) {
+                        return x.moveNext()
+                    })) {
                         const array = enumerators
-                            .select(function (x) { return x.current() })
+                            .select(function (x) {
+                                return x.current()
+                            })
                             .toArray();
                         array.push(index++);
                         return this.yieldReturn(selector.apply(null, array));
-                    }
-                    else {
+                    } else {
                         return this.yieldBreak();
                     }
                 },
@@ -1022,7 +1087,9 @@ Enumerable.prototype.merge = function () {
             function () {
                 enumerators = Enumerable.make(source)
                     .concat(Enumerable.from(args).select(Enumerable.from))
-                    .select(function (x) { return x.getEnumerator() })
+                    .select(function (x) {
+                        return x.getEnumerator()
+                    })
                     .toArray();
             },
             function () {
@@ -1032,8 +1099,7 @@ Enumerable.prototype.merge = function () {
 
                     if (enumerator.moveNext()) {
                         return this.yieldReturn(enumerator.current());
-                    }
-                    else {
+                    } else {
                         enumerator.dispose();
                         enumerators.splice(index--, 1);
                     }
@@ -1089,7 +1155,9 @@ Enumerable.prototype.join = function (inner, outerKeySelector, innerKeySelector,
                     }
                 }
             },
-            function () { Utils.dispose(outerEnumerator); });
+            function () {
+                Utils.dispose(outerEnumerator);
+            });
     });
 };
 
@@ -1137,7 +1205,9 @@ Enumerable.prototype.leftJoin = function (inner, outerKeySelector, innerKeySelec
                     }
                 }
             },
-            function () { Utils.dispose(outerEnumerator); });
+            function () {
+                Utils.dispose(outerEnumerator);
+            });
     });
 };
 
@@ -1166,7 +1236,9 @@ Enumerable.prototype.groupJoin = function (inner, outerKeySelector, innerKeySele
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1200,8 +1272,7 @@ Enumerable.prototype.any = function (predicate) {
             if (predicate(enumerator.current())) return true;
         }
         return false;
-    }
-    finally {
+    } finally {
         Utils.dispose(enumerator);
     }
 };
@@ -1222,7 +1293,9 @@ Enumerable.prototype.concat = function () {
             var secondEnumerator;
 
             return new IEnumerator(
-                function () { firstEnumerator = source.getEnumerator(); },
+                function () {
+                    firstEnumerator = source.getEnumerator();
+                },
                 function () {
                     if (secondEnumerator == null) {
                         if (firstEnumerator.moveNext()) return this.yieldReturn(firstEnumerator.current());
@@ -1234,14 +1307,12 @@ Enumerable.prototype.concat = function () {
                 function () {
                     try {
                         Utils.dispose(firstEnumerator);
-                    }
-                    finally {
+                    } finally {
                         Utils.dispose(secondEnumerator);
                     }
                 });
         });
-    }
-    else {
+    } else {
         const args = arguments;
 
         return new Enumerable(function () {
@@ -1251,7 +1322,9 @@ Enumerable.prototype.concat = function () {
                 function () {
                     enumerators = Enumerable.make(source)
                         .concat(Enumerable.from(args).select(Enumerable.from))
-                        .select(function (x) { return x.getEnumerator() })
+                        .select(function (x) {
+                            return x.getEnumerator()
+                        })
                         .toArray();
                 },
                 function () {
@@ -1260,8 +1333,7 @@ Enumerable.prototype.concat = function () {
 
                         if (enumerator.moveNext()) {
                             return this.yieldReturn(enumerator.current());
-                        }
-                        else {
+                        } else {
                             enumerator.dispose();
                             enumerators.splice(0, 1);
                         }
@@ -1306,8 +1378,7 @@ Enumerable.prototype.insert = function (index, second) {
             function () {
                 try {
                     Utils.dispose(firstEnumerator);
-                }
-                finally {
+                } finally {
                     Utils.dispose(secondEnumerator);
                 }
             });
@@ -1327,8 +1398,7 @@ Enumerable.prototype.alternate = function (alternateValueOrSequence) {
             function () {
                 if (alternateValueOrSequence instanceof Array || alternateValueOrSequence.getEnumerator != null) {
                     alternateSequence = Enumerable.from(Enumerable.from(alternateValueOrSequence).toArray()); // freeze
-                }
-                else {
+                } else {
                     alternateSequence = Enumerable.make(alternateValueOrSequence);
                 }
                 enumerator = source.getEnumerator();
@@ -1339,8 +1409,7 @@ Enumerable.prototype.alternate = function (alternateValueOrSequence) {
                     if (alternateEnumerator != null) {
                         if (alternateEnumerator.moveNext()) {
                             return this.yieldReturn(alternateEnumerator.current());
-                        }
-                        else {
+                        } else {
                             alternateEnumerator = null;
                         }
                     }
@@ -1349,8 +1418,7 @@ Enumerable.prototype.alternate = function (alternateValueOrSequence) {
                         buffer = enumerator.current(); // hasNext
                         alternateEnumerator = alternateSequence.getEnumerator();
                         continue; // GOTO
-                    }
-                    else if (buffer != null) {
+                    } else if (buffer != null) {
                         const retVal = buffer;
                         buffer = null;
                         return this.yieldReturn(retVal);
@@ -1362,8 +1430,7 @@ Enumerable.prototype.alternate = function (alternateValueOrSequence) {
             function () {
                 try {
                     Utils.dispose(enumerator);
-                }
-                finally {
+                } finally {
                     Utils.dispose(alternateEnumerator);
                 }
             });
@@ -1380,8 +1447,7 @@ Enumerable.prototype.contains = function (value, compareSelector) {
             if (compareSelector(enumerator.current()) === value) return true;
         }
         return false;
-    }
-    finally {
+    } finally {
         Utils.dispose(enumerator);
     }
 };
@@ -1395,19 +1461,22 @@ Enumerable.prototype.defaultIfEmpty = function (defaultValue) {
         var isFirst = true;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 if (enumerator.moveNext()) {
                     isFirst = false;
                     return this.yieldReturn(enumerator.current());
-                }
-                else if (isFirst) {
+                } else if (isFirst) {
                     isFirst = false;
                     return this.yieldReturn(defaultValue);
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1449,7 +1518,9 @@ Enumerable.prototype.distinctUntilChanged = function (compareSelector) {
                 }
                 return this.yieldBreak();
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1467,7 +1538,9 @@ Enumerable.prototype.except = function (second, compareSelector) {
             function () {
                 enumerator = source.getEnumerator();
                 keys = new Dictionary(compareSelector);
-                Enumerable.from(second).forEach(function (key) { keys.add(key); });
+                Enumerable.from(second).forEach(function (key) {
+                    keys.add(key);
+                });
             },
             function () {
                 while (enumerator.moveNext()) {
@@ -1479,7 +1552,9 @@ Enumerable.prototype.except = function (second, compareSelector) {
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1499,7 +1574,9 @@ Enumerable.prototype.intersect = function (second, compareSelector) {
                 enumerator = source.getEnumerator();
 
                 keys = new Dictionary(compareSelector);
-                Enumerable.from(second).forEach(function (key) { keys.add(key); });
+                Enumerable.from(second).forEach(function (key) {
+                    keys.add(key);
+                });
                 outs = new Dictionary(compareSelector);
             },
             function () {
@@ -1512,7 +1589,9 @@ Enumerable.prototype.intersect = function (second, compareSelector) {
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1534,12 +1613,10 @@ Enumerable.prototype.sequenceEqual = function (second, compareSelector) {
 
             if (secondEnumerator.moveNext()) return false;
             return true;
-        }
-        finally {
+        } finally {
             Utils.dispose(secondEnumerator);
         }
-    }
-    finally {
+    } finally {
         Utils.dispose(firstEnumerator);
     }
 };
@@ -1582,8 +1659,7 @@ Enumerable.prototype.union = function (second, compareSelector) {
             function () {
                 try {
                     Utils.dispose(firstEnumerator);
-                }
-                finally {
+                } finally {
                     Utils.dispose(secondEnumerator);
                 }
             });
@@ -1629,7 +1705,9 @@ Enumerable.prototype.shuffle = function () {
         var buffer;
 
         return new IEnumerator(
-            function () { buffer = source.toArray(); },
+            function () {
+                buffer = source.toArray();
+            },
             function () {
                 if (buffer.length > 0) {
                     const i = Math.floor(Math.random() * buffer.length);
@@ -1657,7 +1735,7 @@ Enumerable.prototype.weightedSample = function (weightSelector) {
                         if (weight <= 0) return null; // ignore 0
 
                         totalWeight += weight;
-                        return { value: x, bound: totalWeight };
+                        return {value: x, bound: totalWeight};
                     })
                     .toArray();
             },
@@ -1671,8 +1749,7 @@ Enumerable.prototype.weightedSample = function (weightSelector) {
                         const index = Math.floor((lower + upper) / 2);
                         if (sortedByBound[index].bound >= draw) {
                             upper = index;
-                        }
-                        else {
+                        } else {
                             lower = index;
                         }
                     }
@@ -1717,7 +1794,9 @@ Enumerable.prototype.groupBy = function (keySelector, elementSelector, resultSel
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1733,9 +1812,10 @@ Enumerable.prototype.partitionBy = function (keySelector, elementSelector, resul
     var hasResultSelector;
     if (resultSelector == null) {
         hasResultSelector = false;
-        resultSelector = function (key, group) { return new Grouping(key, group); };
-    }
-    else {
+        resultSelector = function (key, group) {
+            return new Grouping(key, group);
+        };
+    } else {
         hasResultSelector = true;
         resultSelector = Utils.createLambda(resultSelector);
     }
@@ -1760,8 +1840,7 @@ Enumerable.prototype.partitionBy = function (keySelector, elementSelector, resul
                 while ((hasNext = enumerator.moveNext()) == true) {
                     if (compareKey === compareSelector(keySelector(enumerator.current()))) {
                         group.push(elementSelector(enumerator.current()));
-                    }
-                    else break;
+                    } else break;
                 }
 
                 if (group.length > 0) {
@@ -1772,15 +1851,16 @@ Enumerable.prototype.partitionBy = function (keySelector, elementSelector, resul
                         key = keySelector(enumerator.current());
                         compareKey = compareSelector(key);
                         group = [elementSelector(enumerator.current())];
-                    }
-                    else group = [];
+                    } else group = [];
 
                     return this.yieldReturn(result);
                 }
 
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1791,7 +1871,9 @@ Enumerable.prototype.buffer = function (count) {
         var enumerator;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 var array = [];
                 var index = 0;
@@ -1802,7 +1884,9 @@ Enumerable.prototype.buffer = function (count) {
                 if (array.length > 0) return this.yieldReturn(array);
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -1848,31 +1932,41 @@ Enumerable.prototype.count = function (predicate) {
 // Overload:function(selector)
 Enumerable.prototype.max = function (selector) {
     if (selector == null) selector = Functions.Identity;
-    return this.select(selector).aggregate(function (a, b) { return (a > b) ? a : b; });
+    return this.select(selector).aggregate(function (a, b) {
+        return (a > b) ? a : b;
+    });
 };
 
 // Overload:function()
 // Overload:function(selector)
 Enumerable.prototype.min = function (selector) {
     if (selector == null) selector = Functions.Identity;
-    return this.select(selector).aggregate(function (a, b) { return (a < b) ? a : b; });
+    return this.select(selector).aggregate(function (a, b) {
+        return (a < b) ? a : b;
+    });
 };
 
 Enumerable.prototype.maxBy = function (keySelector) {
     keySelector = Utils.createLambda(keySelector);
-    return this.aggregate(function (a, b) { return (keySelector(a) > keySelector(b)) ? a : b; });
+    return this.aggregate(function (a, b) {
+        return (keySelector(a) > keySelector(b)) ? a : b;
+    });
 };
 
 Enumerable.prototype.minBy = function (keySelector) {
     keySelector = Utils.createLambda(keySelector);
-    return this.aggregate(function (a, b) { return (keySelector(a) < keySelector(b)) ? a : b; });
+    return this.aggregate(function (a, b) {
+        return (keySelector(a) < keySelector(b)) ? a : b;
+    });
 };
 
 // Overload:function()
 // Overload:function(selector)
 Enumerable.prototype.sum = function (selector) {
     if (selector == null) selector = Functions.Identity;
-    return this.select(selector).aggregate(0, function (a, b) { return a + b; });
+    return this.select(selector).aggregate(0, function (a, b) {
+        return a + b;
+    });
 };
 
 //////////////////
@@ -2022,14 +2116,17 @@ Enumerable.prototype.skip = function (count) {
         return new IEnumerator(
             function () {
                 enumerator = source.getEnumerator();
-                while (index++ < count && enumerator.moveNext()) { }
+                while (index++ < count && enumerator.moveNext()) {
+                }
             },
             function () {
                 return (enumerator.moveNext())
                     ? this.yieldReturn(enumerator.current())
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2045,7 +2142,9 @@ Enumerable.prototype.skipWhile = function (predicate) {
         var isSkipEnd = false;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (!isSkipEnd) {
                     if (enumerator.moveNext()) {
@@ -2062,7 +2161,9 @@ Enumerable.prototype.skipWhile = function (predicate) {
                     : false;
 
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2074,13 +2175,17 @@ Enumerable.prototype.take = function (count) {
         var index = 0;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 return (index++ < count && enumerator.moveNext())
                     ? this.yieldReturn(enumerator.current())
                     : false;
             },
-            function () { Utils.dispose(enumerator); }
+            function () {
+                Utils.dispose(enumerator);
+            }
         );
     });
 };
@@ -2096,13 +2201,17 @@ Enumerable.prototype.takeWhile = function (predicate) {
         var index = 0;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 return (enumerator.moveNext() && predicate(enumerator.current(), index++))
                     ? this.yieldReturn(enumerator.current())
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2119,7 +2228,9 @@ Enumerable.prototype.takeExceptLast = function (count) {
         var q = [];
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 while (enumerator.moveNext()) {
                     if (q.length == count) {
@@ -2130,7 +2241,9 @@ Enumerable.prototype.takeExceptLast = function (count) {
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2144,7 +2257,9 @@ Enumerable.prototype.takeFromLast = function (count) {
         var q = [];
 
         return new IEnumerator(
-            function () { sourceEnumerator = source.getEnumerator(); },
+            function () {
+                sourceEnumerator = source.getEnumerator();
+            },
             function () {
                 while (sourceEnumerator.moveNext()) {
                     if (q.length == count) q.shift();
@@ -2157,7 +2272,9 @@ Enumerable.prototype.takeFromLast = function (count) {
                     ? this.yieldReturn(enumerator.current())
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2174,8 +2291,7 @@ Enumerable.prototype.indexOf = function (item) {
                 return false;
             }
         });
-    }
-    else {
+    } else {
         this.forEach(function (x, i) {
             if (x === item) {
                 found = i;
@@ -2197,8 +2313,7 @@ Enumerable.prototype.lastIndexOf = function (item) {
         this.forEach(function (x, i) {
             if (item(x, i)) result = i;
         });
-    }
-    else {
+    } else {
         this.forEach(function (x, i) {
             if (x === item) result = i;
         });
@@ -2220,7 +2335,9 @@ Enumerable.prototype.asEnumerable = function () {
 
 Enumerable.prototype.toArray = function () {
     var array = [];
-    this.forEach(function (x) { array.push(x); });
+    this.forEach(function (x) {
+        array.push(x);
+    });
     return array;
 };
 
@@ -2303,7 +2420,9 @@ Enumerable.prototype.doAction = function (action) {
         var index = 0;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 if (enumerator.moveNext()) {
                     action(enumerator.current(), index++);
@@ -2311,7 +2430,9 @@ Enumerable.prototype.doAction = function (action) {
                 }
                 return false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2337,9 +2458,9 @@ Enumerable.prototype.force = function () {
     var enumerator = this.getEnumerator();
 
     try {
-        while (enumerator.moveNext()) { }
-    }
-    finally {
+        while (enumerator.moveNext()) {
+        }
+    } finally {
         Utils.dispose(enumerator);
     }
 };
@@ -2363,7 +2484,9 @@ Enumerable.prototype.letBind = function (func) {
                     ? this.yieldReturn(enumerator.current())
                     : false;
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2443,7 +2566,7 @@ if (Utils.hasNativeIteratorSupport()) {
                         value: this.enumerator.current()
                     };
                 } else {
-                    return { done: true };
+                    return {done: true};
                 }
             }
         };
@@ -2461,7 +2584,9 @@ Enumerable.prototype.catchError = function (handler) {
         var enumerator;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 try {
                     return (enumerator.moveNext())
@@ -2472,7 +2597,9 @@ Enumerable.prototype.catchError = function (handler) {
                     return false;
                 }
             },
-            function () { Utils.dispose(enumerator); });
+            function () {
+                Utils.dispose(enumerator);
+            });
     });
 };
 
@@ -2484,7 +2611,9 @@ Enumerable.prototype.finallyAction = function (finallyAction) {
         var enumerator;
 
         return new IEnumerator(
-            function () { enumerator = source.getEnumerator(); },
+            function () {
+                enumerator = source.getEnumerator();
+            },
             function () {
                 return (enumerator.moveNext())
                     ? this.yieldReturn(enumerator.current())
@@ -2572,7 +2701,9 @@ OrderedEnumerable.prototype.getEnumerator = function () {
             var sortContext = SortContext.create(self, null);
             sortContext.GenerateKeys(buffer);
 
-            indexes.sort(function (a, b) { return sortContext.compare(a, b); });
+            indexes.sort(function (a, b) {
+                return sortContext.compare(a, b);
+            });
         },
         function () {
             return (index < indexes.length)
@@ -2630,7 +2761,9 @@ var DisposableEnumerable = function (getEnumerator, dispose) {
 DisposableEnumerable.prototype = new Enumerable();
 
 var ArrayEnumerable = function (source) {
-    this.getSource = function () { return source; };
+    this.getSource = function () {
+        return source;
+    };
 };
 ArrayEnumerable.prototype = new Enumerable();
 
@@ -2702,7 +2835,9 @@ ArrayEnumerable.prototype.skip = function (count) {
         var index;
 
         return new IEnumerator(
-            function () { index = (count < 0) ? 0 : count; },
+            function () {
+                index = (count < 0) ? 0 : count;
+            },
             function () {
                 return (index < source.length)
                     ? this.yieldReturn(source[index++])
@@ -2766,7 +2901,9 @@ ArrayEnumerable.prototype.getEnumerator = function () {
 
     // fast and simple enumerator
     return {
-        current: function () { return source[index]; },
+        current: function () {
+            return source[index];
+        },
         moveNext: function () {
             return ++index < source.length;
         },
@@ -2787,10 +2924,11 @@ WhereEnumerable.prototype.where = function (predicate) {
 
     if (predicate.length <= 1) {
         const prevPredicate = this.prevPredicate;
-        const composedPredicate = function (x) { return prevPredicate(x) && predicate(x); };
+        const composedPredicate = function (x) {
+            return prevPredicate(x) && predicate(x);
+        };
         return new WhereEnumerable(this.prevSource, composedPredicate);
-    }
-    else {
+    } else {
         // if predicate use index, can't compose
         return Enumerable.prototype.where.call(this, predicate);
     }
@@ -2810,7 +2948,9 @@ WhereEnumerable.prototype.getEnumerator = function () {
     var enumerator;
 
     return new IEnumerator(
-        function () { enumerator = source.getEnumerator(); },
+        function () {
+            enumerator = source.getEnumerator();
+        },
         function () {
             while (enumerator.moveNext()) {
                 if (predicate(enumerator.current())) {
@@ -2819,7 +2959,9 @@ WhereEnumerable.prototype.getEnumerator = function () {
             }
             return false;
         },
-        function () { Utils.dispose(enumerator); });
+        function () {
+            Utils.dispose(enumerator);
+        });
 };
 
 var WhereSelectEnumerable = function (source, predicate, selector) {
@@ -2842,10 +2984,11 @@ WhereSelectEnumerable.prototype.select = function (selector) {
 
     if (selector.length <= 1) {
         const prevSelector = this.prevSelector;
-        const composedSelector = function (x) { return selector(prevSelector(x)); };
+        const composedSelector = function (x) {
+            return selector(prevSelector(x));
+        };
         return new WhereSelectEnumerable(this.prevSource, this.prevPredicate, composedSelector);
-    }
-    else {
+    } else {
         // if selector uses index, can't compose
         return Enumerable.prototype.select.call(this, selector);
     }
@@ -2858,7 +3001,9 @@ WhereSelectEnumerable.prototype.getEnumerator = function () {
     var enumerator;
 
     return new IEnumerator(
-        function () { enumerator = source.getEnumerator(); },
+        function () {
+            enumerator = source.getEnumerator();
+        },
         function () {
             while (enumerator.moveNext()) {
                 if (predicate == null || predicate(enumerator.current())) {
@@ -2867,7 +3012,9 @@ WhereSelectEnumerable.prototype.getEnumerator = function () {
             }
             return false;
         },
-        function () { Utils.dispose(enumerator); });
+        function () {
+            Utils.dispose(enumerator);
+        });
 };
 
 ///////////////
@@ -2901,36 +3048,36 @@ var Dictionary = (function () {
         this.last = null;
     };
     EntryList.prototype =
-    {
-        addLast: function (entry) {
-            if (this.last != null) {
-                this.last.next = entry;
-                entry.prev = this.last;
-                this.last = entry;
-            } else this.first = this.last = entry;
-        },
+        {
+            addLast: function (entry) {
+                if (this.last != null) {
+                    this.last.next = entry;
+                    entry.prev = this.last;
+                    this.last = entry;
+                } else this.first = this.last = entry;
+            },
 
-        replace: function (entry, newEntry) {
-            if (entry.prev != null) {
-                entry.prev.next = newEntry;
-                newEntry.prev = entry.prev;
-            } else this.first = newEntry;
+            replace: function (entry, newEntry) {
+                if (entry.prev != null) {
+                    entry.prev.next = newEntry;
+                    newEntry.prev = entry.prev;
+                } else this.first = newEntry;
 
-            if (entry.next != null) {
-                entry.next.prev = newEntry;
-                newEntry.next = entry.next;
-            } else this.last = newEntry;
+                if (entry.next != null) {
+                    entry.next.prev = newEntry;
+                    newEntry.next = entry.next;
+                } else this.last = newEntry;
 
-        },
+            },
 
-        remove: function (entry) {
-            if (entry.prev != null) entry.prev.next = entry.next;
-            else this.first = entry.next;
+            remove: function (entry) {
+                if (entry.prev != null) entry.prev.next = entry.next;
+                else this.first = entry.next;
 
-            if (entry.next != null) entry.next.prev = entry.prev;
-            else this.last = entry.prev;
-        }
-    };
+                if (entry.next != null) entry.next.prev = entry.prev;
+                else this.last = entry.prev;
+            }
+        };
 
     // Overload:function()
     // Overload:function(compareSelector)
@@ -2941,116 +3088,118 @@ var Dictionary = (function () {
         this.compareSelector = (compareSelector == null) ? Functions.Identity : compareSelector;
     };
     Dictionary.prototype =
-    {
-        add: function (key, value) {
-            var compareKey = this.compareSelector(key);
-            var hash = computeHashCode(compareKey);
-            var entry = new HashEntry(key, value);
-            if (callHasOwnProperty(this.buckets, hash)) {
-                const array = this.buckets[hash];
+        {
+            add: function (key, value) {
+                var compareKey = this.compareSelector(key);
+                var hash = computeHashCode(compareKey);
+                var entry = new HashEntry(key, value);
+                if (callHasOwnProperty(this.buckets, hash)) {
+                    const array = this.buckets[hash];
+                    for (let i = 0; i < array.length; i++) {
+                        if (this.compareSelector(array[i].key) === compareKey) {
+                            this.entryList.replace(array[i], entry);
+                            array[i] = entry;
+                            return;
+                        }
+                    }
+                    array.push(entry);
+                } else {
+                    this.buckets[hash] = [entry];
+                }
+                this.countField++;
+                this.entryList.addLast(entry);
+            },
+
+            get: function (key) {
+                var compareKey = this.compareSelector(key);
+                var hash = computeHashCode(compareKey);
+                if (!callHasOwnProperty(this.buckets, hash)) return undefined;
+
+                var array = this.buckets[hash];
+                for (let i = 0; i < array.length; i++) {
+                    const entry = array[i];
+                    if (this.compareSelector(entry.key) === compareKey) return entry.value;
+                }
+                return undefined;
+            },
+
+            set: function (key, value) {
+                var compareKey = this.compareSelector(key);
+                var hash = computeHashCode(compareKey);
+                if (callHasOwnProperty(this.buckets, hash)) {
+                    const array = this.buckets[hash];
+                    for (let i = 0; i < array.length; i++) {
+                        if (this.compareSelector(array[i].key) === compareKey) {
+                            const newEntry = new HashEntry(key, value);
+                            this.entryList.replace(array[i], newEntry);
+                            array[i] = newEntry;
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            },
+
+            contains: function (key) {
+                var compareKey = this.compareSelector(key);
+                var hash = computeHashCode(compareKey);
+                if (!callHasOwnProperty(this.buckets, hash)) return false;
+
+                var array = this.buckets[hash];
+                for (let i = 0; i < array.length; i++) {
+                    if (this.compareSelector(array[i].key) === compareKey) return true;
+                }
+                return false;
+            },
+
+            clear: function () {
+                this.countField = 0;
+                this.buckets = {};
+                this.entryList = new EntryList();
+            },
+
+            remove: function (key) {
+                var compareKey = this.compareSelector(key);
+                var hash = computeHashCode(compareKey);
+                if (!callHasOwnProperty(this.buckets, hash)) return;
+
+                var array = this.buckets[hash];
                 for (let i = 0; i < array.length; i++) {
                     if (this.compareSelector(array[i].key) === compareKey) {
-                        this.entryList.replace(array[i], entry);
-                        array[i] = entry;
+                        this.entryList.remove(array[i]);
+                        array.splice(i, 1);
+                        if (array.length == 0) delete this.buckets[hash];
+                        this.countField--;
                         return;
                     }
                 }
-                array.push(entry);
-            } else {
-                this.buckets[hash] = [entry];
+            },
+
+            count: function () {
+                return this.countField;
+            },
+
+            toEnumerable: function () {
+                var self = this;
+                return new Enumerable(function () {
+                    var currentEntry;
+
+                    return new IEnumerator(
+                        function () {
+                            currentEntry = self.entryList.first;
+                        },
+                        function () {
+                            if (currentEntry != null) {
+                                const result = {key: currentEntry.key, value: currentEntry.value};
+                                currentEntry = currentEntry.next;
+                                return this.yieldReturn(result);
+                            }
+                            return false;
+                        },
+                        Functions.Blank);
+                });
             }
-            this.countField++;
-            this.entryList.addLast(entry);
-        },
-
-        get: function (key) {
-            var compareKey = this.compareSelector(key);
-            var hash = computeHashCode(compareKey);
-            if (!callHasOwnProperty(this.buckets, hash)) return undefined;
-
-            var array = this.buckets[hash];
-            for (let i = 0; i < array.length; i++) {
-                const entry = array[i];
-                if (this.compareSelector(entry.key) === compareKey) return entry.value;
-            }
-            return undefined;
-        },
-
-        set: function (key, value) {
-            var compareKey = this.compareSelector(key);
-            var hash = computeHashCode(compareKey);
-            if (callHasOwnProperty(this.buckets, hash)) {
-                const array = this.buckets[hash];
-                for (let i = 0; i < array.length; i++) {
-                    if (this.compareSelector(array[i].key) === compareKey) {
-                        const newEntry = new HashEntry(key, value);
-                        this.entryList.replace(array[i], newEntry);
-                        array[i] = newEntry;
-                        return true;
-                    }
-                }
-            }
-            return false;
-        },
-
-        contains: function (key) {
-            var compareKey = this.compareSelector(key);
-            var hash = computeHashCode(compareKey);
-            if (!callHasOwnProperty(this.buckets, hash)) return false;
-
-            var array = this.buckets[hash];
-            for (let i = 0; i < array.length; i++) {
-                if (this.compareSelector(array[i].key) === compareKey) return true;
-            }
-            return false;
-        },
-
-        clear: function () {
-            this.countField = 0;
-            this.buckets = {};
-            this.entryList = new EntryList();
-        },
-
-        remove: function (key) {
-            var compareKey = this.compareSelector(key);
-            var hash = computeHashCode(compareKey);
-            if (!callHasOwnProperty(this.buckets, hash)) return;
-
-            var array = this.buckets[hash];
-            for (let i = 0; i < array.length; i++) {
-                if (this.compareSelector(array[i].key) === compareKey) {
-                    this.entryList.remove(array[i]);
-                    array.splice(i, 1);
-                    if (array.length == 0) delete this.buckets[hash];
-                    this.countField--;
-                    return;
-                }
-            }
-        },
-
-        count: function () {
-            return this.countField;
-        },
-
-        toEnumerable: function () {
-            var self = this;
-            return new Enumerable(function () {
-                var currentEntry;
-
-                return new IEnumerator(
-                    function () { currentEntry = self.entryList.first; },
-                    function () {
-                        if (currentEntry != null) {
-                            const result = { key: currentEntry.key, value: currentEntry.value };
-                            currentEntry = currentEntry.next;
-                            return this.yieldReturn(result);
-                        }
-                        return false;
-                    },
-                    Functions.Blank);
-            });
-        }
-    };
+        };
 
     return Dictionary;
 })();

--- a/linq.js
+++ b/linq.js
@@ -323,6 +323,20 @@ Enumerable.from = function (obj) {
         }
 
         // iterable object
+        if (typeof Symbol !== 'undefined' && typeof obj[Symbol.iterator] !== 'undefined') {
+            let iterator = obj[Symbol.iterator]();
+            return new Enumerable(function () {
+                return new IEnumerator(
+                    Functions.Blank,
+                    function () {
+                        var next = iterator.next();
+                        return (next.done ? false : (this.yieldReturn(next.value)));
+                    },
+                    Functions.Blank);
+            });
+        }
+
+        // iterator object
         if (typeof Symbol !== 'undefined' && typeof obj.next !== 'undefined') {
             return new Enumerable(function () {
                 return new IEnumerator(

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -24,7 +24,7 @@ test("Symbol.iterator", function () {
     deepEqual(actual2, Array.from(expected));
 });
 
-test("from Iterable", function () {
+test("from Generator", function () {
     function* words() {
         yield "abc";
         yield "def";
@@ -39,7 +39,27 @@ test("from Iterable", function () {
     deepEqual(actual, ["abc", "def"]);
 });
 
-test("from Symbol.iterator", function () {
+test("from Iterable object", function () {
+    const map = new Map();
+
+    map.set(1, 2);
+    map.set(2, 4);
+
+    deepEqual(Enumerable
+            .from(map)
+            .select(item => ({key: item[0], value: item[1]}))
+            .select(item=>item.key)
+            .toArray(),
+        [1, 2]);
+
+    let actual = [];
+    for (var a of map) {
+        actual.push(a[0]);
+    }
+    deepEqual(actual, [1, 2]);
+});
+
+test("from Iterator object", function () {
     const n = {
         // This is just a simple replacement for the data structure that needs to be traversed.
         // It may actually be a tree or other data structure implemented by a custom traversal.


### PR DESCRIPTION
## BackGround

In C#, iterable objects can be iterated over using LINQ in the following way:

```csharp
var list = users
  .Where(u => user.Name.Contains("Yi"))
  .Select(u => u.id);
```

Here, users is an object of type `IEnumerable<T>`, meaning it implements the `IEnumerator` interface.

[IEnumerable | MSDN](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1)

In JS/Ts, a similar concept exists for iterables.
For example, `Map` is an iterable object that can be iterated by `for...of` because it implements the `Iterable<T>` interface (Ts), i.e., it contains a `[Symbol.iterator]` method.

## Feature

This pull request enhances the from function by enabling it to accept `Iterable<T>` objects.

This PR aims to automatically invoke the `[Symbol.iterator]` method on objects that possess it to obtain an iterator, and then use this iterator to construct an `Enumerable`.

## Key Changes

- **New**:

  ```JavaScript
    // Enumerable.from
    {
        // iterable object
        if (typeof Symbol !== 'undefined' && typeof obj[Symbol.iterator] !== 'undefined') {
            let iterator;
            return new Enumerable(function () {
                return new IEnumerator(
                    function () {
                        iterator = obj[Symbol.iterator]()
                    },
                    function () {
                        var next = iterator.next();
                        return (next.done ? false : (this.yieldReturn(next.value)));
                    },
                    Functions.Blank);
            });
        }
    }
  ```

  - check if `obj` has a `[Symbol.iterator]` method. if ture, treat it as an iterable object.

## Why

- **More Direct Usage**: This change will accept iterable objects directly. For instance:

  ```JavaScript
    const map = new Map();

    map.set(1, 2);
    map.set(2, 4);

    let result = Enumerable.from(map)
        .select(item => ({key: item[0], value: item[1]}))
        .select(item => item.key)
        .toArray();

    console.log(result);
  ```

  The above code will throw an error in `4.0.2` version because `map` is an iterable object, but linq treats it as an iterator and accesses its next function directly:

  ```text
  Uncaught TypeError: obj.next is not a function
  ```

  In [`PR#110`](https://github.com/mihaifm/linq/pull/110), an empty array is provided. The reason is that `PR#110` expects an iterator rather than an iterable object. The following code will return the expected results:

  ```JavaScript
    Enumerable.from(map[Symbol.iterator]())
  ```

This PR is more dangerous than last time. The last PR actually targeted a function signature that was not correctly aligned with linq.d.ts and corrected it to be fully compliant.
This PR adds a new feature, enabling the `Enumerable.from` function to accept parameters of type `Iterable<T>`. This is a completely new feature and may introduce new problems.

Thank you very much to the author for pointing out the problem of modifying irrelevant code. I will try to avoid this behavior in subsequent PRs.
