### PR TITLE
feat: use iterable object directly

### DIFF
--- a/linq.d.ts
+++ b/linq.d.ts
@@ -20,6 +20,7 @@ declare namespace Enumerable {
   export function from(obj: string): IEnumerable<string>;
   export function from<T>(obj: T[]): IEnumerable<T>;
   export function from<T>(obj: Iterator<T>): IEnumerable<T>;
+  export function from<T>(obj: Iterable<T>): IEnumerable<T>;
   export function from<T>(obj: { length: number;[x: number]: T; }): IEnumerable<T>;
   export function from<K extends PropertyKey, T>(obj: Record<K, T>): IEnumerable<{ key: K; value: T }>;
   export function make<T>(element: T): IEnumerable<T>;

--- a/linq.js
+++ b/linq.js
@@ -323,6 +323,20 @@ Enumerable.from = function (obj) {
         }
 
         // iterable object
+        if (typeof Symbol !== 'undefined' && typeof obj[Symbol.iterator] !== 'undefined') {
+            let iterator;
+            return new Enumerable(function () {
+                return new IEnumerator(
+                    function () { iterator = obj[Symbol.iterator]()},
+                    function () {
+                        var next = iterator.next();
+                        return (next.done ? false : (this.yieldReturn(next.value)));
+                    },
+                    Functions.Blank);
+            });
+        }
+
+        // iterator object
         if (typeof Symbol !== 'undefined' && typeof obj.next !== 'undefined') {
             return new Enumerable(function () {
                 return new IEnumerator(

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -11,16 +11,13 @@ test("for..of", function () {
     deepEqual(actual, [1, 2, 3]);
 });
 
-test("Symbol.iterator", function () {
-    let actual = [1, 2, 3, 4];
+test("Symbol.iterator", function ()
+{
+    let actual = [1,2,3,4];
     let expected = Array.from(Enumerable.from(actual));
     deepEqual(actual, expected);
-    let actual2 = actual.map(function (x) {
-        return x * 2
-    }); // [2,4,6,8];
-    expected = Enumerable.from(actual).select(function (x) {
-        return x * 2
-    });
+    let actual2 = actual.map(function(x) { return x * 2 }); // [2,4,6,8];
+    expected = Enumerable.from(actual).select(function(x) { return x * 2 });
     deepEqual(actual2, Array.from(expected));
 });
 

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -36,7 +36,27 @@ test("from Iterable", function () {
     deepEqual(actual, ["abc", "def"]);
 });
 
-test("from Symbol.iterator", function () {
+test("from Iterable object", function () {
+    const map = new Map();
+
+    map.set(1, 2);
+    map.set(2, 4);
+
+    deepEqual(Enumerable
+            .from(map)
+            .select(item => ({key: item[0], value: item[1]}))
+            .select(item=>item.key)
+            .toArray(),
+        [1, 2]);
+
+    let actual = [];
+    for (var a of map) {
+        actual.push(a[0]);
+    }
+    deepEqual(actual, [1, 2]);
+});
+
+test("from Iterator object", function () {
     const n = {
         // This is just a simple replacement for the data structure that needs to be traversed.
         // It may actually be a tree or other data structure implemented by a custom traversal.

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -21,7 +21,7 @@ test("Symbol.iterator", function ()
     deepEqual(actual2, Array.from(expected));
 });
 
-test("from Iterable", function () {
+test("from Generator", function () {
     function* words() {
         yield "abc";
         yield "def";


### PR DESCRIPTION
## BackGround

In C#, iterable objects can be iterated over using LINQ in the following way:

```csharp
var list = users
  .Where(u => user.Name.Contains("Yi"))
  .Select(u => u.id);
```

Here, users is an object of type `IEnumerable<T>`, meaning it implements the `IEnumerator` interface.

[IEnumerable | MSDN](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1)

In JS/Ts, a similar concept exists for iterables.
For example, `Map` is an iterable object that can be iterated by `for...of` because it implements the `Iterable<T>` interface (Ts), i.e., it contains a `[Symbol.iterator]` method.

## Feature

This pull request enhances the from function by enabling it to accept `Iterable<T>` objects.

This PR aims to automatically invoke the `[Symbol.iterator]` method on objects that possess it to obtain an iterator, and then use this iterator to construct an `Enumerable`.

## Key Changes

- **New**:

  ```JavaScript
    // Enumerable.from
    {
        // iterable object
        if (typeof Symbol !== 'undefined' && typeof obj[Symbol.iterator] !== 'undefined') {
            let iterator;
            return new Enumerable(function () {
                return new IEnumerator(
                    function () {
                        iterator = obj[Symbol.iterator]()
                    },
                    function () {
                        var next = iterator.next();
                        return (next.done ? false : (this.yieldReturn(next.value)));
                    },
                    Functions.Blank);
            });
        }
    }
  ```

  - check if `obj` has a `[Symbol.iterator]` method. if ture, treat it as an iterable object.

## Why

- **More Direct Usage**: This change will accept iterable objects directly. For instance:

  ```JavaScript
    const map = new Map();

    map.set(1, 2);
    map.set(2, 4);

    let result = Enumerable.from(map)
        .select(item => ({key: item[0], value: item[1]}))
        .select(item => item.key)
        .toArray();

    console.log(result);
  ```

  The above code will throw an error in `4.0.2` version because `map` is an iterable object, but linq treats it as an iterator and accesses its next function directly:

  ```text
  Uncaught TypeError: obj.next is not a function
  ```

  In [`PR#110`](https://github.com/mihaifm/linq/pull/110), an empty array is provided. The reason is that `PR#110` expects an iterator rather than an iterable object. The following code will return the expected results:

  ```JavaScript
    Enumerable.from(map[Symbol.iterator]())
  ```

This PR is more dangerous than last time. The last PR actually targeted a function signature that was not correctly aligned with linq.d.ts and corrected it to be fully compliant.
This PR adds a new feature, enabling the `Enumerable.from` function to accept parameters of type `Iterable<T>`. This is a completely new feature and may introduce new problems.

Thank you very much to the author for pointing out the problem of modifying irrelevant code. I will try to avoid this behavior in subsequent PRs.

This PR also reverts iterator.js:14-22 with changes from an unrelated commit.
